### PR TITLE
Redis host override and multistage builder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.vscode/
+*.pyc
+__pycache__
+allspark_cli
+allspark_daemon

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,13 @@ run_tests: clean pull_required_images setup_docker_network allspark_cli allspark
 pull_required_images:
 	docker pull macrobytes/dev-spark-cluster:latest && \
 	docker pull macrobytes/allspark-compute:latest
-     
+
 clean:
 	rm /tmp/allspark_exit_status; \
 	redis-cli flushall; \
 	docker network rm allspark_bridged_newtork 2>/dev/null; \
 	rm -f allspark_cli allspark_daemon /allspark/exit_status; \
 	docker rm -f /dev-spark-cluster 2>/dev/null || true
+
+build_orchestrator_image:
+	docker build -t macrobytes/allspark-orchestration-service -f dist/docker-setup/allspark-orchestration-service/Dockerfile .

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"allspark/logger"
 	"allspark/util/serializer"
+	"os"
+	"strings"
 )
 
 // AllSparkConfig - allspark configuration parameters struct
@@ -26,10 +28,18 @@ var config AllSparkConfig
 // Init - loads allspark configuration parameters into configParams
 func Init(path string) {
 	err := serializer.DeserializePath(path, &config)
-	logger.GetInfo().Printf("config parameters: %+v", config)
 	if err != nil {
 		logger.GetFatal().Fatalln(err)
 	}
+	redis_host := os.Getenv("ALLSPARK_REDIS_HOST")
+	if len(redis_host) > 0 {
+		if strings.Contains(redis_host, ":") {
+			config.RedisHost = redis_host
+		} else {
+			logger.GetError().Printf("Skipping ALLSPARK_REDIS_HOST=%s as it is not host/port format", redis_host);
+		}
+	}
+	logger.GetInfo().Printf("config parameters: %+v", config)
 }
 
 // GetAllSparkConfig - returns allspark configuration parameters

--- a/dist/docker-setup/allspark-orchestration-service/Dockerfile
+++ b/dist/docker-setup/allspark-orchestration-service/Dockerfile
@@ -1,10 +1,27 @@
+FROM clearlinux/golang:1.18 AS builder
+
+WORKDIR /allspark-orchestrator
+ADD go.mod .
+ADD go.sum .
+COPY allspark_orchestrator allspark_orchestrator
+COPY api api
+COPY cloud cloud
+COPY daemon daemon
+COPY datastore datastore
+COPY logger logger
+COPY monitor monitor
+COPY util util
+
+RUN go build -o allspark_daemon ./allspark_orchestrator
+
 FROM clearlinux:latest
 
 EXPOSE 32418
 
 WORKDIR /allspark
 
-ADD allspark_daemon allspark_daemon
-ADD config.local.json config.json
+COPY --from=builder /allspark-orchestrator/allspark_daemon allspark_daemon
+ADD dist/docker-setup/allspark-orchestration-service/config.local.json config.json
 
-ENTRYPOINT /allspark/allspark_daemon /allspark/config.json
+ENTRYPOINT ["/allspark/allspark_daemon"] 
+CMD ["/allspark/config.json"]


### PR DESCRIPTION
In order to use this outside of a specific AWS account and not hardcode the region-specific ElastiCache/Redis hosts, the changes to daemon.go will look at `ALLSPARK_REDIS_HOST` in the docker runtime environment and use it if it exists and has a `:` in the definition, logging an error otherwise.

As docker containers are either Linux or Windows runtime based (for this use case, Linux only), copying the Go binaries is not sufficient if built on a non-Linux platform. Therefore I had change the orchestrator Dockerfile to establish a multi-stage build - first build the Go project then copy the thin binaries to the actual image run-time.